### PR TITLE
Safer and more reliable device getter

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,23 +4,24 @@ inherits = require('util').inherits, es = require('event-stream'), through = req
 inherits(MpgPlayer, EventEmitter);
 exports.MpgPlayer = MpgPlayer;
 
-exports.getDevices = function(callback) {
-	execCmd('aplay -L', function(raw) {
-		var lines = raw.split('\n'), devices = [];
-		for(var i=0,l=lines.length; i<l; i++) {
-			var line = lines[i]; if(line[0] == 'h' && line[1] == 'w' && line[2] == ':') {
-				var name = lines[i+1]; if(name) {
-					name = name.substring(0,name.indexOf(',')).trim();
-					devices.push({name:name,address:line});
-				}
-			}
-		}
-		devices.get = function(n) {
-			for(var i=0,l=this.length; i<l; i++) if(this[i].name == n) return this[i];
-			return null;
-		};
-		callback(devices);
-	});
+exports.getDevices = function() {
+	try {
+      return cp.execSync('cat /proc/asound/pcm')
+        .toString()
+        .split('\n')
+        .reduce((acc, line) => {
+          const [rawAddress, name] = line.split(': ');
+          const addr =
+            rawAddress &&
+            rawAddress
+              .split('-')
+              .map(i => parseInt(i))
+              .join(',');
+          return addr ? [...acc, { address: `hw:${addr}`, name: `${name} [${addr}]` }] : acc;
+        }, []);
+    } catch {
+      return [];
+    }
 }
 
 function MpgPlayer(device, noFrames) {


### PR DESCRIPTION
The former getDevices function did not list anything at all for me, so I investigated and found out, that I can list out /proc/asound/pcm file to get all sound devices in a format that is way easier to parse. Also, I thing synchronicity in this case is preferred.